### PR TITLE
make random id generation more performant

### DIFF
--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -599,7 +599,7 @@ function requestResponseMessage(
   transfers?: Transferable[]
 ): Promise<WireValue> {
   return new Promise((resolve) => {
-    const id = generateUUID();
+    const id = Math.trunc(Math.random() * Number.MAX_SAFE_INTEGER).toString();
     ep.addEventListener("message", function l(ev: MessageEvent) {
       if (!ev.data || !ev.data.id || ev.data.id !== id) {
         return;
@@ -614,9 +614,3 @@ function requestResponseMessage(
   });
 }
 
-function generateUUID(): string {
-  return new Array(4)
-    .fill(0)
-    .map(() => Math.floor(Math.random() * Number.MAX_SAFE_INTEGER).toString(16))
-    .join("-");
-}


### PR DESCRIPTION
This PR introduces a simpler random id generation which is much more performant, which is especially noticeable when sending many requests in a short time.

Upstream PR: https://github.com/GoogleChromeLabs/comlink/pull/654