### PR TITLE
Avoid creation of temporary proxies

### DIFF
--- a/tests/node/main.mjs
+++ b/tests/node/main.mjs
@@ -25,4 +25,32 @@ describe("node", () => {
       expect(await otherProxy(20, 1)).to.equal(21);
     });
   });
+
+  describe("Comlink across workers (wrapped object)", function () {
+    beforeEach(function () {
+      this.worker = new Worker("./tests/node/worker-obj.mjs");
+    });
+
+    afterEach(function () {
+      this.worker.terminate();
+    });
+
+    it("can communicate", async function () {
+      const proxy = Comlink.wrap(nodeEndpoint(this.worker));
+      for (let i = 0; i < 10; i++) {
+        expect(await proxy.add(1, i)).to.equal(1 + i);
+        expect(await proxy.mult(1, i)).to.equal(1 * i);
+      }
+    });
+
+    it("can tunnels a new endpoint with createEndpoint", async function () {
+      const proxy = Comlink.wrap(nodeEndpoint(this.worker));
+      const otherEp = await proxy[Comlink.createEndpoint]();
+      const otherProxy = Comlink.wrap(otherEp);
+      for (let i = 0; i < 10; i++) {
+        expect(await otherProxy.add(1, i)).to.equal(1 + i);
+        expect(await otherProxy.mult(1, i)).to.equal(1 * i);
+      }
+    });
+  });
 });

--- a/tests/node/worker-obj.mjs
+++ b/tests/node/worker-obj.mjs
@@ -1,0 +1,10 @@
+import { parentPort } from "worker_threads";
+import * as Comlink from "../../dist/esm/comlink.mjs";
+import nodeEndpoint from "../../dist/esm/node-adapter.mjs";
+
+const obj = {
+  add: (a, b) => a + b,
+  mult: (a, b) => a * b,
+};
+
+Comlink.expose(obj, nodeEndpoint(parentPort));


### PR DESCRIPTION
### Public-Facing Changes
Avoid creation of temporary proxies

### Description
As described in https://github.com/foxglove/studio/pull/7452, temporary proxies are created when one does not hoist the proxy:

> 
> ```ts
> const remote = comlink.wrap(new Worker("..."));
> for (...) {
>   await remote.someFunc();  // creates a temporary proxy on every call
> }
> ```
> 
> This can be avoided by creating the proxy only once:
> 
> ```ts
> const remoteSomeFunc = remote.someFunc;  // create the proxy once
> for (...) {
>   await remoteSomeFunc();  // no temporary proxy created
> }
> ```

This PR avoids creation of temporary proxies by caching them in a map. 