### PR TITLE
Change requestResponseMessage identifier to a number

### DIFF
--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -8,6 +8,7 @@ import {
   Endpoint,
   EventSource,
   Message,
+  MessageID,
   MessageType,
   PostMessageWithOrigin,
   WireValue,
@@ -228,13 +229,13 @@ type SerializedThrownValue =
   | { isError: true; value: Error }
   | { isError: false; value: unknown };
 type PendingListenersMap = Map<
-  number,
+  MessageID,
   (value: WireValue | PromiseLike<WireValue>) => void
 >;
 type EndpointWithPendingListeners = {
   endpoint: Endpoint;
   pendingListeners: PendingListenersMap;
-  nextRequestId: number;
+  nextRequestId: MessageID;
 };
 
 /**

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -54,7 +54,7 @@ export interface HandlerWireValue {
 
 export type WireValue = RawWireValue | HandlerWireValue;
 
-export type MessageID = string;
+export type MessageID = number;
 
 export const enum MessageType {
   GET = "GET",

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -40,13 +40,13 @@ export const enum WireValueType {
 }
 
 export interface RawWireValue {
-  id?: string;
+  id?: MessageID;
   type: WireValueType.RAW;
   value: {};
 }
 
 export interface HandlerWireValue {
-  id?: string;
+  id?: MessageID;
   type: WireValueType.HANDLER;
   name: string;
   value: unknown;


### PR DESCRIPTION
### Changelog
Performance improvement for RPC calls

### Description
Every request dispatched over the postMessage boundary is tagged with an identifier. The promise for the request is stored in a map keyed by this ID. When the remote end responds to the request, the dispatch layer looks up the promise to resolve by this ID.

Prior to this change, the dispatch logic would assign random string ids. This meant that each RPC dispatch would need to:
1. Generate a random integer
2. Convert it to a string
3. Transfer the string over the worker boundary
4. Transfer the string back over the worker boundary when responding to the RPC

These identifiers are internal and there is no need for them to be random or strings. We can save on all of the above work by using an incrementing counter.

