### PR TITLE
Hoist some map and reduce closures to stable functions

### DIFF
--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -586,15 +586,14 @@ function myFlat<T>(arr: (T | T[])[]): T[] {
 }
 
 /** Get the first item of a tuple */
-function firstItem<O, T>(v: [O, T]): O {
+function firstItem<T>(v: [T, unknown]): T {
   return v[0]
 }
 
 /** Get the second item of a tuple */
-function secondItem<O, T>(v: [O, T]): T {
+function secondItem<T>(v: [unknown, T]): T {
   return v[1];
 }
-
 
 function processArguments(argumentList: any[]): [WireValue[], Transferable[]] {
   const processed = argumentList.map(toWireValue);

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -54,7 +54,7 @@ export interface HandlerWireValue {
 
 export type WireValue = RawWireValue | HandlerWireValue;
 
-export type MessageID = string;
+export type MessageID = number;
 
 export const enum MessageType {
   GET = "GET",

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -40,13 +40,13 @@ export const enum WireValueType {
 }
 
 export interface RawWireValue {
-  id?: string;
+  id?: MessageID;
   type: WireValueType.RAW;
   value: {};
 }
 
 export interface HandlerWireValue {
-  id?: string;
+  id?: MessageID;
   type: WireValueType.HANDLER;
   name: string;
   value: unknown;


### PR DESCRIPTION
### Changelog
Performance improvements

### Description
These functions do not close over any value and can be hoisted to module level. This avoids runtime cost of making these functions at these call sites every time.