### PR TITLE
Change Message and Wire type enums to numbers

### DIFF
--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -33,10 +33,10 @@ export interface Endpoint extends EventSource {
 }
 
 export const enum WireValueType {
-  RAW = "RAW",
-  PROXY = "PROXY",
-  THROW = "THROW",
-  HANDLER = "HANDLER",
+  RAW = 1,
+  PROXY = 2,
+  THROW = 3,
+  HANDLER = 4,
 }
 
 export interface RawWireValue {
@@ -57,12 +57,12 @@ export type WireValue = RawWireValue | HandlerWireValue;
 export type MessageID = number;
 
 export const enum MessageType {
-  GET = "GET",
-  SET = "SET",
-  APPLY = "APPLY",
-  CONSTRUCT = "CONSTRUCT",
-  ENDPOINT = "ENDPOINT",
-  RELEASE = "RELEASE",
+  GET = 10,
+  SET = 11,
+  APPLY = 12,
+  CONSTRUCT = 13,
+  ENDPOINT = 14,
+  RELEASE = 15,
 }
 
 export interface GetMessage {


### PR DESCRIPTION
### Changelog
Performance improvements

### Docs
None

### Description
These enums are internal values for indicating the type of a message or wire value. We can avoid transferring a string by changing them to numbers. The typescript code is unchanged but the produced javascript uses numbers rather than strings which saves on transfer cost, string initialization/copy cost, and comparison cost with no loss in readability of the source.

