### PR TITLE
Fix npm publish auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4.4.0
+        with:
+          # Needed for NODE_AUTH_TOKEN env var to work for npm publish
+          # https://github.com/actions/setup-node#:~:text=NODE_AUTH_TOKEN.%0A%20%20%20%20%23%20Default%3A%20%27%27-,registry,-%2Durl%3A%20%27
+          registry-url: https://registry.npmjs.org
 
       - run: npm install
 


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
This is too stupid to explain. It seems that npm doesn't have a "native" env var it reads for auth and instead uses the configured value in `.npmrc`. Setting the `registry-url` with the `setup-node` action is the glue that connects the env var `NODE_AUTH_TOKEN` to authenticate when publishing.