### PR TITLE
Enable NPM trusted publishing with OIDC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,15 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
+      contents: read
       # https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/setup-node@v6
         with:
-          # Needed for NODE_AUTH_TOKEN env var to work for npm publish
-          # https://github.com/actions/setup-node#:~:text=NODE_AUTH_TOKEN.%0A%20%20%20%20%23%20Default%3A%20%27%27-,registry,-%2Durl%3A%20%27
           registry-url: https://registry.npmjs.org
 
       - run: npm install
@@ -32,6 +31,4 @@ jobs:
 
       - name: Publish to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+        run: npx npm@11.7.0 publish --provenance --access public

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 dist
 .*_cache*
 package-lock.json
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/foxglove/comlink.git"
+    "url": "git+https://github.com/foxglove/comlink.git"
   },
   "license": "Apache-2.0",
   "devDependencies": {


### PR DESCRIPTION
## Summary
Update npm publish workflow to use OIDC trusted publishing with provenance.

## Changes
- Add `id-token: write` and `contents: read` permissions for OIDC authentication
- Update to `npx npm@11.7.0 publish` with `--provenance` flag for supply chain security
- Update actions to v6
- Remove `NODE_AUTH_TOKEN` secret (no longer needed with OIDC)

## Status
✅ Trusted publishing has been configured on npmjs.com for this package.