### PR TITLE
include cause property in communicated error fields

### DIFF
--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -267,7 +267,7 @@ const throwTransferHandler: TransferHandler<
   deserialize(serialized) {
     if (serialized.isError) {
       throw Object.assign(
-        new Error(serialized.value.message),
+        new Error(serialized.value.message, { cause: serialized.value.cause }),
         serialized.value
       );
     }

--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -256,6 +256,7 @@ const throwTransferHandler: TransferHandler<
           message: value.message,
           name: value.name,
           stack: value.stack,
+          cause: value.cause,
         },
       };
     } else {

--- a/tests/same_window.comlink.test.js
+++ b/tests/same_window.comlink.test.js
@@ -98,11 +98,11 @@ describe("Comlink in the same realm", function () {
     expect(await thing.x).to.be.undefined;
   });
 
-  it("can keep the stack and message of thrown errors", async function () {
+  it("can keep the stack, message and cause of thrown errors", async function () {
     let stack;
     const thing = Comlink.wrap(this.port1);
     Comlink.expose((_) => {
-      const error = Error("OMG");
+      const error = Error("OMG", { cause: "the cause" });
       stack = error.stack;
       throw error;
     }, this.port2);
@@ -113,6 +113,7 @@ describe("Comlink in the same realm", function () {
       expect(err).to.not.eq("Should have thrown");
       expect(err.message).to.equal("OMG");
       expect(err.stack).to.equal(stack);
+      expect(err.cause).to.equal("the cause");
     }
   });
 


### PR DESCRIPTION
Prior to this PR, the `cause` field of thrown errors was not passed across the comlink link. This PR adds support for this